### PR TITLE
Refactor: Implement layered .env configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,10 +1,23 @@
 # .env.template - Environment Variables for Self-Hosted Docker Stacks
 #
 # INSTRUCTIONS:
-# 1. Copy this file to '.env' in the same directory: cp .env.template .env
-# 2. Edit the '.env' file with YOUR specific settings.
+# 1. Copy this file to '.env' in the same directory (the root of the project):
+#    cp .env.template .env
+# 2. Edit THIS ROOT '.env' file with YOUR specific global/shared settings.
 # 3. DO NOT commit your actual '.env' file to Git. Add '.env' to your .gitignore!
 # 4. Generate strong, unique passwords for all credentials.
+#
+# LAYERED .ENV CONFIGURATION:
+# - This root '.env' file provides the base configuration for all services.
+# - Each service stack (e.g., 00-proxy/, 00-auth/) can also have its own local '.env' file.
+# - When a service starts, Docker Compose will load variables in this order:
+#   1. From this root '../.env' file.
+#   2. From the service's local './.env' file (if it exists).
+# - Variables in a local './.env' file will OVERRIDE those from the root '../.env' file
+#   for that specific service stack.
+# - Use local './.env' files for service-specific overrides or for variables that
+#   only pertain to a single stack. Check the '.env.example' in each service
+#   directory for examples.
 #
 
 # === General Settings ===

--- a/00-auth/.env.example
+++ b/00-auth/.env.example
@@ -1,0 +1,18 @@
+# 00-auth/.env.example
+# This file is for service-specific environment variable overrides or additions for the Authelia stack.
+# Variables set here will take precedence over those in the root ../.env file.
+#
+# Most Authelia configuration is done via its configuration.yml, which itself can use
+# environment variables sourced from ../.env (like AUTHELIA_JWT_SECRET, DOMAIN_NAME).
+#
+# Add variables here only if you need to override a global setting specifically for
+# the Authelia container, or for variables that might influence its startup
+# environment if not covered by configuration.yml or the global .env.
+
+# Example: Overriding a global variable (less common)
+# TZ=Europe/Paris
+
+# Authelia's primary variables like AUTHELIA_JWT_SECRET, AUTHELIA_DOMAIN, DOMAIN_NAME
+# are expected to be in the root ../.env file as they are used by Authelia's configuration.yml
+# and also potentially by Caddy for integration.
+# No common stack-specific overrides are typical here unless for advanced debugging.

--- a/00-auth/docker-compose.yml
+++ b/00-auth/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     container_name: authelia
     restart: unless-stopped
     env_file:
-      - ../.env # Load variables from the root .env file
+      - ../.env  # Load global .env first
+      - ./.env   # Load service-specific .env (overrides globals, adds specifics)
     volumes:
       - ./configuration.yml:/config/configuration.yml:ro
       - authelia_data:/var/lib/authelia
@@ -14,10 +15,9 @@ services:
       - 9091 # Authelia's default port
     networks:
       - proxy_network
-    depends_on:
-      # Optional: if you have redis in another compose file for Authelia
-      # - redis # Ensure redis is started before Authelia if used
-      pass
+    # depends_on: # No hard dependencies within this specific compose file for now.
+                 # If you add, e.g., a Redis service in this file for Authelia, uncomment and use:
+                 #  - redis_service_name
     healthcheck:
       disable: true # Set to true if you are not using the built-in healthcheck
       # test: ["CMD", "authelia", "healthcheck"]

--- a/00-proxy/.env.example
+++ b/00-proxy/.env.example
@@ -1,0 +1,16 @@
+# 00-proxy/.env.example
+# This file is for service-specific environment variable overrides or additions for the proxy stack.
+# Variables set here will take precedence over those in the root ../.env file.
+#
+# Most variables are typically managed in the root ../.env file.
+# Only add variables here if you need to override a global setting specifically for
+# Caddy or ddclient, or if there's a variable only relevant to this stack.
+
+# Example: Overriding a global variable (less common, usually done for testing)
+# TZ=America/Los_Angeles
+
+# Example: A variable that might be specific to Caddy if not managed globally
+# CADDY_LOG_LEVEL=DEBUG
+
+# ddclient itself is primarily configured by DDCLIENT_* variables in the root ../.env
+# No typical overrides are needed here for ddclient unless you have a very specific scenario.

--- a/00-proxy/docker-compose.yml
+++ b/00-proxy/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     container_name: caddy
     restart: unless-stopped
     env_file:
-      - ../.env # Load variables from the root .env file
+      - ../.env  # Load global .env first
+      - ./.env   # Load service-specific .env (overrides globals, adds specifics)
 
     ports:
       # Essential ports for web traffic - MUST be exposed on host
@@ -54,7 +55,8 @@ services:
     container_name: ddclient
     restart: unless-stopped
     env_file:
-      - ../.env
+      - ../.env  # Load global .env first
+      - ./.env   # Load service-specific .env (overrides globals, adds specifics)
     environment:
       - PUID=${DEFAULT_PUID}
       - PGID=${DEFAULT_PGID}

--- a/06-notes/.env.example
+++ b/06-notes/.env.example
@@ -1,0 +1,17 @@
+# 06-notes/.env.example
+# This file is for service-specific environment variable overrides or additions for the NextTrilium stack.
+# Variables set here will take precedence over those in the root ../.env file.
+#
+# Most variables are typically managed in the root ../.env file.
+# The TRILIUM_NOTES_DOMAIN and optionally TRILIUM_NOTES_DATA_DIR are primary examples
+# managed in the root .env.
+
+# Example: Overriding a global variable (less common)
+# TZ=America/New_York
+
+# Example: If Trilium itself had a container-specific env var not managed elsewhere
+# TRILIUM_SOME_SPECIFIC_SETTING=some_value
+
+# The main variables for this stack (TRILIUM_NOTES_DOMAIN, TRILIUM_NOTES_DATA_DIR, TZ)
+# are expected to be set in the root ../.env file.
+# This local .env is mostly a placeholder unless specific overrides are needed.

--- a/06-notes/docker-compose.yml
+++ b/06-notes/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     container_name: trilium_notes
     restart: unless-stopped
     env_file:
-      - ../.env # Load variables from the root .env file
+      - ../.env  # Load global .env first
+      - ./.env   # Load service-specific .env (overrides globals, adds specifics)
     environment:
       # TRILIUM_DATA_DIR is used internally by the image.
       # We map a volume to this path inside the container.

--- a/07-code-server/.env.example
+++ b/07-code-server/.env.example
@@ -1,0 +1,21 @@
+# 07-code-server/.env.example
+# This file is for service-specific environment variable overrides or additions for the Codium stack.
+# Variables set here will take precedence over those in the root ../.env file.
+#
+# Most variables (DEFAULT_PUID, DEFAULT_PGID, TZ, CODIUM_DOMAIN, CODIUM_CONFIG_DIR)
+# are typically managed in the root ../.env file.
+
+# Example: Overriding a global variable
+# TZ=Asia/Tokyo
+
+# Example: Setting the Codium-specific password if you chose to use it
+# This would override any VSCODING_PASSWORD potentially set in the root .env,
+# or provide it if it's only set here.
+# VSCODING_PASSWORD=a_very_specific_password_for_this_codium_instance
+
+# Example: If you wanted a different default workspace specifically for an instance defined here
+# DEFAULT_WORKSPACE=/config/workspace/my_other_project
+
+# The main variables for this stack (CODIUM_DOMAIN, CODIUM_CONFIG_DIR, PUID, PGID, TZ, optional VSCODING_PASSWORD)
+# are expected to be set in the root ../.env file.
+# This local .env is mostly for overrides or very specific instance settings.

--- a/07-code-server/docker-compose.yml
+++ b/07-code-server/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     container_name: codium
     restart: unless-stopped
     env_file:
-      - ../.env
+      - ../.env  # Load global .env first
+      - ./.env   # Load service-specific .env (overrides globals, adds specifics)
     environment:
       - PUID=${DEFAULT_PUID}
       - PGID=${DEFAULT_PGID}

--- a/08-automation/.env.example
+++ b/08-automation/.env.example
@@ -1,0 +1,18 @@
+# 08-automation/.env.example
+# This file is for service-specific environment variable overrides or additions for the Watchtower stack.
+# Variables set here will take precedence over those in the root ../.env file.
+#
+# Key Watchtower variables (WATCHTOWER_POLL_INTERVAL, WATCHTOWER_CLEANUP, WATCHTOWER_LABEL_ENABLE)
+# are typically managed in the root ../.env file for global update strategy.
+# Notification settings would also usually be global.
+
+# Example: Overriding global Watchtower poll interval for this specific instance (if you ran multiple Watchtowers)
+# WATCHTOWER_POLL_INTERVAL=3600 # Check every hour, overriding global setting
+
+# Example: Enabling label-only mode specifically for a Watchtower instance defined here
+# WATCHTOWER_LABEL_ENABLE=true
+
+# Most Watchtower settings like poll interval, cleanup, label enabling, and notification
+# endpoints are best managed globally in the root ../.env file.
+# Use this file if you have a very specific reason to override those for a particular
+# Watchtower instance (though this stack currently only defines one).

--- a/08-automation/docker-compose.yml
+++ b/08-automation/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     container_name: watchtower
     restart: unless-stopped
     env_file:
-      - ../.env
+      - ../.env  # Load global .env first
+      - ./.env   # Load service-specific .env (overrides globals, adds specifics)
     environment:
       # Interval to check for updates (e.g., "0 0 4 * * *" for 4 AM daily - cron expression)
       # Or simpler interval like "86400" (seconds for 24 hours)

--- a/README.md
+++ b/README.md
@@ -94,19 +94,18 @@ Follow these steps carefully to prepare your environment:
 3.  **Configure Environment Variables (`.env`):**
     *   **This is the most critical configuration step.**
     *   Copy the template: `cp .env.template .env`
-    *   **Edit the `.env` file** (`nano .env`, `vim .env`, etc.).
-    *   **Carefully replace ALL placeholder values** with your actual information:
-        *   `TZ`: Your timezone.
-        *   `DEFAULT_PUID`, `DEFAULT_PGID`: Your user/group IDs (`id -u`, `id -g`).
-        *   `DOMAIN_NAME`: Your root domain (e.g., `example.com`).
-        *   `ACME_EMAIL`: Your email for Let's Encrypt.
-        *   `CLOUDFLARE_API_TOKEN`: For Caddy's DNS challenge.
-        *   `AUTHELIA_DOMAIN`: Subdomain for Authelia (e.g., `auth.example.com`). This is `${AUTHELIA_DOMAIN}` in Caddy/Authelia configs.
-        *   `AUTHELIA_JWT_SECRET`: **Generate a strong random string** (e.g., `openssl rand -hex 32`).
-        *   `TRILIUM_NOTES_DOMAIN`: Subdomain for Trilium Notes (e.g., `notes.example.com`).
-        *   `CODIUM_DOMAIN`: Subdomain for Codium (e.g., `code.example.com`).
-        *   Review other variables like `DDCLIENT_*` if using dynamic DNS.
-    *   **Security:** Use a password manager. Ensure API tokens have minimum required permissions. `.gitignore` prevents `.env` commit.
+    *   **Edit the root `.env` file** (`nano .env`, `vim .env`, etc.) located in the main project directory.
+    *   **Carefully replace ALL placeholder values in this root `.env` file** with your actual global and shared information. This file is the primary source for most configurations.
+        *   Examples: `TZ`, `DEFAULT_PUID`, `DEFAULT_PGID`, `DOMAIN_NAME`, `ACME_EMAIL`, `CLOUDFLARE_API_TOKEN`, `AUTHELIA_DOMAIN`, `AUTHELIA_JWT_SECRET`, `TRILIUM_NOTES_DOMAIN`, `CODIUM_DOMAIN`, `DDCLIENT_*` variables, `WATCHTOWER_*` variables, etc.
+    *   **Layered `.env` Files (New Structure):**
+        *   This project now uses a layered approach for environment variables.
+        *   The primary, global configuration is sourced from the root `.env` file you just edited.
+        *   Each service stack directory (e.g., `00-proxy/`, `00-auth/`) can also contain its own local `.env` file.
+        *   When a service starts, Docker Compose loads variables first from the root `../.env` file, and then from the service's local `./.env` file (if it exists).
+        *   Variables set in a local `./.env` file will **override** those from the root `.env` file for that specific service stack.
+        *   Use local `./.env` files for service-specific overrides or for variables that only pertain to a single stack (e.g., a debug flag for a specific service).
+        *   Each service directory contains a `./.env.example` file. You can copy this to `./.env` within that service directory if you need to make local overrides or add stack-specific variables. For most cases, you might not need local `.env` files if all your settings are global.
+    *   **Security:** Use a password manager for secrets. Ensure API tokens have minimum required permissions. The `.gitignore` file prevents any `.env` files from being committed.
 4.  **Configure Authelia Users:**
     *   After starting Authelia (e.g., `cd 00-auth && docker-compose up -d authelia`), you need to create users.
     *   Edit `00-auth/users_database.yml`. Follow the instructions within that file.


### PR DESCRIPTION
- Updated all service docker-compose.yml files to load environment variables first from the root ../.env and then from a local ./env file, allowing local overrides.
- Created .env.example files in each service subdirectory as templates for local environment variable settings.
- Updated the root .env.template with a detailed explanation of the new layered .env strategy.
- Updated the main README.md to document how layered .env files work, their loading order, and purpose.